### PR TITLE
Add type definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,41 @@
+declare type Options = {
+  /** mean parameter, default=1 */
+  lambda?: number;
+  /** boolean indicating if the function should return a new data structure, default=true */
+  copy?: boolean;
+  /** accessor function for accessing array values */
+  acessor?: Function;
+  /** deep get/set key path */
+  path?: string;
+  /** deep get/set key path separator, default="." */
+  sep?: string;
+  /** output data type, default="float64" */
+  dtype?: string;
+}
+
+/**
+ * Evaluates the quantile function for a Poisson distribution.
+ * @param p input value
+ * @param options function options
+ * @returns quantile function value(s)
+ */
+declare function quantile(p: number, options?: Options): number;
+/**
+ * Evaluates the quantile function for a Poisson distribution.
+ * @param p input value
+ * @param options function options
+ * @returns quantile function value(s)
+ */
+declare function quantile(p: number[], options?: Options): number[];
+/**
+ * Evaluates the quantile function for a Poisson distribution.
+ * @param p input value
+ * @param options function options
+ * @returns quantile function value(s)
+ */
+declare function quantile(p: Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array,
+  options?: Options):
+  Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array;
+  
+
+export default quantile;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "codecov": "istanbul cover ./node_modules/.bin/_mocha --dir ./reports/codecov/coverage --report lcovonly -- -R spec && cat ./reports/codecov/coverage/lcov.info | codecov && rm -rf ./reports/codecov"
   },
   "main": "./lib",
+  "types": "./lib",
   "repository": {
     "type": "git",
     "url": "git://github.com/distributions-io/poisson-quantile.git"


### PR DESCRIPTION
This adds basic type definitions for the exported `quantile` function as well as the `options` object it takes as a parameter. This will make it wasier for this package to be used in typescript projects.

The `Matrix` type is not included in the type definitions, as there appear to be no type definitions for it and it is part of a separate package.